### PR TITLE
Fixed game text breaks after search 

### DIFF
--- a/public/games.html
+++ b/public/games.html
@@ -95,7 +95,7 @@
             x[i].style.display = "none";
           }
           else {
-            x[i].style.display = "inline-block";
+            x[i].style.display = "flex";
           }
         }
         document.document.getElementsByClassName('card').style.display = "block";


### PR DESCRIPTION


# Issue: The card has display: flex, and after a search, it was set to inline-block.


## Example video before the fix: 


https://github.com/user-attachments/assets/f4f65395-6041-433a-aade-526e56c28c0e


